### PR TITLE
Install Docker client from the official Docker repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,20 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
     sudo git curl gnupg software-properties-common wget \
     ca-certificates apt-utils build-essential vim \
     iproute2 net-tools iputils-* ifupdown cmake acl \
-    npm time mariadb-client postgresql-client jq python docker.io
+    npm time mariadb-client postgresql-client jq python
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
+# Install Docker client from the official Docker repository
+RUN install -m 0755 -d /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+RUN chmod a+r /etc/apt/keyrings/docker.gpg
+RUN echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg]" \
+        "https://download.docker.com/linux/debian"$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+        tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update
+RUN apt-get install docker-ce-cli docker-compose-plugin
 
 # Run as user "runner", uid: 1001, gid: group ID for docker on the runner VM . Make this user a passwordless sudoer
 RUN useradd -u 1001 -ms /bin/bash -g docker runner


### PR DESCRIPTION
Change to install Docker client from the official repository. 
Only the `docker-ce-cli` client and the `docker-compose` plugin will be installed instead of the whole `docker.io` package from the Debian repository.