### PR TITLE
Dockerfile: Add env var to enable installation of libdecaf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG REPO_URL=https://github.com/PowerDNS/pdns.git
 ARG DOCKER_GID=1000
 
 ENV CLANG_VERSION='13'
+ENV DECAF_SUPPORT=yes
 
 # Reusable layer for base update
 RUN apt-get update && apt-get -y dist-upgrade && apt-get clean


### PR DESCRIPTION
Enable (back) the installation of `libdecaf` as part of the `auth-build-dependencies`.

Since this [commit](https://github.com/PowerDNS/pdns/commit/825560a1c8fb99fbd28518a7a43bf0e6ceeb87c3) at the PDNS repository, this library is no longer installed by default. A new environment variable is required.

Image build tested here: <https://github.com/romeroalx/base-pdns-ci-image/actions/runs/6729259315/job/18289839366>

PDNS run tested here: <https://github.com/romeroalx/pdns/actions/runs/6729285056>