### PR TITLE
GH Actions: Add a job for purging old versions of the PDNS CI images

### DIFF
--- a/.github/workflows/build-debian-images.yaml
+++ b/.github/workflows/build-debian-images.yaml
@@ -47,3 +47,28 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           docker push ${{ env.image-id-lowercase }}:${{ env.IMAGE_TAG }}
+
+  purge-old-images:
+    name: Purge old PDNS CI images
+    needs: build-and-push-debian-images
+    runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        image-id: 
+        - debian-11-pdns-base
+        - debian-12-pdns-base
+    steps:
+      - name: Get repository name
+        run: |
+          echo "${{ github.repository }}" | awk -F'/' '{print "repo-name="$2}' >> "$GITHUB_ENV"
+
+      - name: Purge old images keeping the 5 more recent ones
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: ${{ env.repo-name }}/${{ matrix.image-id }}
+          package-type: container
+          min-versions-to-keep: 5


### PR DESCRIPTION
By default, GitHub does not purge old versions of a given package.

Adding a job for purging old versions of an image, keeping the five more recent ones by using the action `delete-package-versions`. More information [here](https://github.com/actions/delete-package-versions)

This is the current status for the images we build in the public repository:

- `base-pdns-ci-image/debian-11-pdns-base`: currently [213](https://github.com/PowerDNS/base-pdns-ci-image/pkgs/container/base-pdns-ci-image%2Fdebian-11-pdns-base/versions) versions

- `base-pdns-ci-image/debian-12-pdns-base`: currently [23](https://github.com/PowerDNS/base-pdns-ci-image/pkgs/container/base-pdns-ci-image%2Fdebian-12-pdns-base/versions) versions

[Here](https://github.com/romeroalx/base-pdns-ci-image/actions/runs/7221955697/job/19678139649) is a test run of this new job.