### PR TITLE
GH Actions: fix CI pipeline for XDP packages

### DIFF
--- a/.github/workflows/build-debian-images.yaml
+++ b/.github/workflows/build-debian-images.yaml
@@ -19,6 +19,7 @@ jobs:
           debian-release-name: bullseye-slim
         - image-id: debian-12-pdns-base
           debian-release-name: bookworm-slim
+      fail-fast: false
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -61,6 +62,7 @@ jobs:
         image-id: 
         - debian-11-pdns-base
         - debian-12-pdns-base
+      fail-fast: false
     steps:
       - name: Get repository name
         run: |

--- a/.github/workflows/build-debian-images.yaml
+++ b/.github/workflows/build-debian-images.yaml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: |
           echo "image-id-lowercase=ghcr.io/${{ github.repository }}/${{ matrix.image-id }}" | tr '[:upper:]' '[:lower:]' >> "$GITHUB_ENV"
@@ -37,7 +37,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -67,8 +67,10 @@ jobs:
           echo "${{ github.repository }}" | awk -F'/' '{print "repo-name="$2}' >> "$GITHUB_ENV"
 
       - name: Purge old images keeping the 5 more recent ones
-        uses: actions/delete-package-versions@v4
+        # FIXME: move to tag v5 when available.
+        uses: actions/delete-package-versions@v5.0.0
         with: 
           package-name: ${{ env.repo-name }}/${{ matrix.image-id }}
           package-type: container
           min-versions-to-keep: 5
+          delete-only-untagged-versions: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN inv install-clang
 RUN inv install-clang-tidy-tools
 RUN inv install-auth-build-deps
 RUN inv install-rec-build-deps
-RUN inv install-dnsdist-build-deps
+RUN inv install-dnsdist-build-deps $([ "$(. /etc/os-release && echo $VERSION_CODENAME)" = "bullseye" ] && echo "--skipXDP=True")
 
 # Copy permissions for /opt and node_modules like Github runner VMs
 RUN sudo mkdir -p /usr/local/lib/node_modules


### PR DESCRIPTION
Package `libxdp-dev` is available from the `backports` repository for Debian Bullseye.

Use a more recent version of actions to avoid warnings related to Nodejs 16.

Test PDNS `build-and-test-all` workflow - Debian 12: [https://github.com/romeroalx/pdns/actions/runs/7728319018](https://github.com/romeroalx/pdns/actions/runs/7728319018)

 Test PDNS `build-and-test-all` workflow - Debian 11: [https://github.com/romeroalx/pdns/actions/runs/7728319010](https://github.com/romeroalx/pdns/actions/runs/7728319010)