### PR TITLE
Dockerfile: Remove change permissions of /opt/pdns-auth as libdecaf no longer installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,6 @@ RUN inv install-dnsdist-build-deps $([ "$(. /etc/os-release && echo $VERSION_COD
 # Copy permissions for /opt and node_modules like Github runner VMs
 RUN sudo mkdir -p /usr/local/lib/node_modules
 RUN sudo chmod 777 /opt /usr/local/bin /usr/share /usr/local/lib/node_modules
-RUN sudo chmod 777 -R /opt/pdns-auth
 
 WORKDIR ${USER_HOME}
 


### PR DESCRIPTION
This [PR](https://github.com/PowerDNS/pdns/pull/14926) removed support for' lib decaf' from `PowerDNS/pdns`.

For this reason, the folder `/opt/pdns-auth` no longer exists when building the image. See [error](https://github.com/PowerDNS/base-pdns-ci-image/actions/runs/12216814332/job/34080321661)

This PR removes changing permissions of a directory that no longer exists.

Test: [https://github.com/romeroalx/pdns/actions/runs/12223341207](https://github.com/romeroalx/pdns/actions/runs/12223341207) 

