### PR TITLE
Avoid errors when changing permissions for /opt/pdns-auth if the folder does not exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN inv install-dnsdist-build-deps $([ "$(. /etc/os-release && echo $VERSION_COD
 # Copy permissions for /opt and node_modules like Github runner VMs
 RUN sudo mkdir -p /usr/local/lib/node_modules
 RUN sudo chmod 777 /opt /usr/local/bin /usr/share /usr/local/lib/node_modules
-RUN sudo chmod 777 -R /opt/pdns-auth
+RUN sudo chmod 777 -R /opt/pdns-auth || true
 
 WORKDIR ${USER_HOME}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN inv install-dnsdist-build-deps $([ "$(. /etc/os-release && echo $VERSION_COD
 # Copy permissions for /opt and node_modules like Github runner VMs
 RUN sudo mkdir -p /usr/local/lib/node_modules
 RUN sudo chmod 777 /opt /usr/local/bin /usr/share /usr/local/lib/node_modules
+RUN sudo chmod 777 -R /opt/pdns-auth
 
 WORKDIR ${USER_HOME}
 


### PR DESCRIPTION
Avoid errors when changing permissions for `/opt/pdns-auth` if the folder does not exist.

I did not find a better way than trailing `|| true`. The Dockerfile syntax did not tolerate well neither `[ -d /opt/pdns-auth] && ..` nor `test -d /opt/pdns-auth && ..`

Tests:

```
docker run -ti ghcr.io/romeroalx/base-pdns-ci-image/debian-12-pdns-base:master ls -al /opt
total 8
drwxrwxrwx 1 root root 4096 Dec  2 00:00 .
drwxr-xr-x 1 root root 4096 Dec 13 09:41 ..

docker run -ti ghcr.io/romeroalx/base-pdns-ci-image/debian-12-pdns-base:auth-4.9.x ls -al /opt
total 12
drwxrwxrwx 1 root root 4096 Dec 13 09:32 .
drwxr-xr-x 1 root root 4096 Dec 13 09:41 ..
drwxrwxrwx 1 root root 4096 Dec 13 09:32 pdns-auth
```